### PR TITLE
feat: Initial rewrite of MCP Paradex server to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mcp-paradex-ts",
+  "module": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "start": "bun src/index.ts"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.13.3",
+    "@paradex/sdk": "^0.6.0",
+    "zod": "^3.22.4"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,63 @@
+import { createServer, runServer } from './server/server';
+import { config, loadConfig } from './utils/config';
+import { McpServer } from '@modelcontextprotocol/sdk/server';
+
+// Import tools and resources to ensure they are registered
+// This will be done by importing their respective modules which should call server.registerTool/Resource
+// For example:
+// import './tools/account';
+// import './tools/market';
+// import './resources/market';
+// import './resources/system';
+// etc.
+
+// These imports will be added as we create the tool/resource files.
+// For now, the registration will happen inside createServer or dedicated functions called by it.
+
+async function main() {
+  // Configuration is loaded when config.ts is imported, but explicitly calling it ensures clarity.
+  const appConfig = loadConfig(); // or just use the exported 'config' object
+
+  const serverInstance: McpServer = createServer(appConfig);
+
+  // Register tools and resources by importing their modules
+  // This is a common pattern: module side effects register things.
+  // Ensure these files exist and correctly register with the serverInstance passed or a global one.
+  // For now, assuming createServer handles initial registration or we'll do it explicitly.
+  // Example (if createServer doesn't handle it, and assuming a way to pass serverInstance or use a global singleton):
+  // await import('./tools/accountTools').then(module => module.register(serverInstance, appConfig));
+  // await import('./tools/marketTools').then(module => module.register(serverInstance, appConfig));
+  // await import('./resources/marketResources').then(module => module.register(serverInstance, appConfig));
+  // await import('./resources/systemResources').then(module => module.register(serverInstance, appConfig));
+
+  // The actual registration of tools/resources will be handled in their respective files
+  // or a central registration function called within `createServer`.
+  // For now, let's assume `createServer` wires up the basics or we will iterate.
+
+  const transport = appConfig.NODE_ENV === 'production' ? 'sse' : (process.env.MCP_TRANSPORT || "stdio");
+  const port = appConfig.SERVER_PORT;
+
+  console.log(`Using transport: ${transport}, Port: ${port} (if applicable)`);
+
+  await runServer(serverInstance, transport, port);
+}
+
+main().catch(error => {
+  console.error("Failed to start server:", error);
+  process.exit(1);
+});
+
+process.on('SIGINT', () => {
+  console.info("\nSIGINT received. Shutting down MCP Paradex server...");
+  // Perform any cleanup here if necessary
+  // e.g., server.close();
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  console.info("\nSIGTERM received. Shutting down MCP Paradex server...");
+  // Perform any cleanup here if necessary
+  process.exit(0);
+});
+
+console.log("src/index.ts loaded");

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+
+// Based on models.AccountSummary in Python
+export const AccountSummarySchema = z.object({
+    account_id: z.string(), // Or number
+    username: z.string().optional(), // If available
+    total_balance: z.string().transform(parseFloat), // Example: "10000.50"
+    available_balance: z.string().transform(parseFloat),
+    margin_balance: z.string().transform(parseFloat),
+    initial_margin: z.string().transform(parseFloat),
+    maintenance_margin: z.string().transform(parseFloat),
+    unrealized_pnl: z.string().transform(parseFloat),
+    realized_pnl: z.string().transform(parseFloat),
+    equity: z.string().transform(parseFloat),
+    leverage: z.string().transform(parseFloat).optional(), // Current leverage if applicable
+    // Add other fields from Python's AccountSummary model as needed
+    // e.g., currency (USDC), account_type, etc.
+    currency: z.string().default("USDC"), // Assuming default, make optional if not always present
+});
+export type AccountSummary = z.infer<typeof AccountSummarySchema>;
+
+// Based on models.Position in Python
+export const PositionSchema = z.object({
+    market_id: z.string(), // Or symbol
+    side: z.enum(['LONG', 'SHORT', 'FLAT']), // Or "BUY"/"SELL", or numerical representation
+    size: z.string().transform(parseFloat),
+    entry_price: z.string().transform(parseFloat),
+    mark_price: z.string().transform(parseFloat),
+    liquidation_price: z.string().transform(parseFloat).optional(),
+    unrealized_pnl: z.string().transform(parseFloat),
+    realized_pnl: z.string().transform(parseFloat).optional(), // PnL for this position if closed partially
+    initial_margin: z.string().transform(parseFloat),
+    maintenance_margin: z.string().transform(parseFloat),
+    leverage: z.string().transform(parseFloat).optional(),
+    // Add other fields like timestamp, last_updated_time etc.
+    timestamp: z.number().int().optional(), // Creation or last update time
+});
+export type Position = z.infer<typeof PositionSchema>;
+export const PositionArraySchema = z.array(PositionSchema);
+
+// Based on models.Fill in Python
+export const FillSchema = z.object({
+    id: z.string(), // Fill/Trade ID
+    order_id: z.string(),
+    market_id: z.string(), // Or symbol
+    price: z.string().transform(parseFloat),
+    quantity: z.string().transform(parseFloat), // Amount/Size
+    side: z.enum(['BUY', 'SELL']), // Or "BID"/"ASK" etc.
+    liquidity: z.enum(['MAKER', 'TAKER']).optional(), // Liquidity indicator
+    fee: z.string().transform(parseFloat),
+    fee_currency: z.string(),
+    timestamp: z.number().int(), // Unix timestamp (ms)
+    // Add role (maker/taker), trade_type etc. if available
+});
+export type Fill = z.infer<typeof FillSchema>;
+export const FillArraySchema = z.array(FillSchema);
+
+// Based on models.Transaction in Python
+export const TransactionSchema = z.object({
+    id: z.string(),
+    type: z.string(), // e.g., "DEPOSIT", "WITHDRAWAL", "TRADE_FEE", "FUNDING_PAYMENT", "REALIZED_PNL"
+    amount: z.string().transform(parseFloat),
+    currency: z.string(),
+    status: z.string().optional(), // e.g., "COMPLETED", "PENDING", "FAILED"
+    timestamp: z.number().int(), // Unix timestamp (ms)
+    details: z.record(z.any()).optional(), // For any other specific details, like trade_id, funding_market_id
+    // address_from: z.string().optional(), // For deposits/withdrawals
+    // address_to: z.string().optional(),   // For deposits/withdrawals
+    // transaction_hash: z.string().optional(), // Blockchain transaction hash if applicable
+});
+export type Transaction = z.infer<typeof TransactionSchema>;
+export const TransactionArraySchema = z.array(TransactionSchema);
+
+
+// Models for Vaults (from Python's mcp_paradex/models.py, assuming structure)
+// These were not explicitly requested to be read but are part of the overall structure.
+
+export const VaultSchema = z.object({
+  id: z.string(),
+  asset: z.string(), // e.g., "USDC"
+  total_balance: z.string().transform(parseFloat),
+  available_balance: z.string().transform(parseFloat),
+  // other vault specific fields
+  apy: z.string().transform(parseFloat).optional(),
+  strategy: z.string().optional(),
+});
+export type Vault = z.infer<typeof VaultSchema>;
+export const VaultArraySchema = z.array(VaultSchema);
+
+export const VaultSummarySchema = z.object({
+  total_value_locked_usd: z.string().transform(parseFloat),
+  number_of_vaults: z.number().int(),
+  // other summary fields
+});
+export type VaultSummary = z.infer<typeof VaultSummarySchema>;
+
+
+// Model for Order (from Python's mcp_paradex/models.py, assuming structure)
+export const OrderStateSchema = z.object({
+    id: z.string(), // Order ID
+    client_order_id: z.string().optional(),
+    market_id: z.string(),
+    side: z.enum(["BUY", "SELL"]),
+    type: z.enum(["LIMIT", "MARKET", "STOP_LOSS", "TAKE_PROFIT"]), // etc.
+    status: z.enum(["OPEN", "CLOSED", "CANCELED", "FILLED", "PARTIALLY_FILLED", "EXPIRED"]),
+    price: z.string().transform(parseFloat).optional(), // Optional for market orders
+    quantity: z.string().transform(parseFloat), // Original quantity
+    filled_quantity: z.string().transform(parseFloat),
+    remaining_quantity: z.string().transform(parseFloat),
+    average_fill_price: z.string().transform(parseFloat).optional(),
+    created_at: z.number().int(), // timestamp
+    updated_at: z.number().int().optional(), // timestamp
+    // time_in_force: z.enum(["GTC", "IOC", "FOK"]).optional(),
+    // post_only: z.boolean().optional(),
+    // reduce_only: z.boolean().optional(),
+});
+export type OrderState = z.infer<typeof OrderStateSchema>;
+export const OrderStateArraySchema = z.array(OrderStateSchema);
+
+
+console.log("src/models/account.ts loaded");
+
+// As with market.ts, the actual field names, types (string vs number from API),
+// and enum values need to be verified against the @paradex/sdk responses.
+// parseFloat transformations assume string numbers from API.
+// Optional fields are marked with .optional().

--- a/src/models/market.test.ts
+++ b/src/models/market.test.ts
@@ -1,0 +1,88 @@
+import { expect, test, describe } from "bun:test";
+import { MarketDetailsSchema, MarketSummarySchema, OHLCVSchema, BBOSchema, OrderbookSchema, TradeSchema, FundingDataSchema } from "./market";
+
+describe("Market Models (Zod Schemas)", () => {
+    describe("MarketDetailsSchema", () => {
+        test("should validate correct market details", () => {
+            const data = {
+                symbol: "BTC-PERP",
+                base_asset: "BTC",
+                quote_asset: "USDC",
+                tick_size: "0.1",
+                min_order_size: "0.001",
+                max_order_size: "100",
+                lot_size: "1",
+                contract_type: "PERP",
+                asset_kind: "PERP",
+                is_active: true,
+            };
+            const parsed = MarketDetailsSchema.safeParse(data);
+            expect(parsed.success).toBe(true);
+            if (parsed.success) {
+                expect(parsed.data.tick_size).toBe(0.1);
+                expect(parsed.data.min_order_size).toBe(0.001);
+            }
+        });
+
+        test("should fail validation for incorrect types", () => {
+            const data = {
+                symbol: "ETH-PERP",
+                base_asset: "ETH",
+                quote_asset: "USDC",
+                tick_size: "not-a-number", // Invalid
+                min_order_size: "0.01",
+                max_order_size: "1000",
+                lot_size: "1",
+                contract_type: "PERP",
+                asset_kind: "PERP",
+            };
+            const parsed = MarketDetailsSchema.safeParse(data);
+            expect(parsed.success).toBe(false);
+        });
+
+        test("should fail if required fields are missing", () => {
+            const data = { base_asset: "SOL" }; // Missing symbol, quote_asset etc.
+            const parsed = MarketDetailsSchema.safeParse(data);
+            expect(parsed.success).toBe(false);
+        });
+    });
+
+    describe("MarketSummarySchema", () => {
+        test("should validate correct market summary", () => {
+            const data = {
+                symbol: "BTC-PERP",
+                mark_price: "40000.50",
+                last_price: "40001.00",
+                open_interest: "1000",
+                high_price_24h: "41000",
+                low_price_24h: "39000",
+                volume_24h: "50000000",
+                price_change_percent_24h: "2.5",
+            };
+            const parsed = MarketSummarySchema.safeParse(data);
+            expect(parsed.success).toBe(true);
+            if (parsed.success) {
+                expect(parsed.data.mark_price).toBe(40000.50);
+            }
+        });
+    });
+
+    // Add similar tests for OHLCVSchema, BBOSchema, OrderbookSchema, TradeSchema, FundingDataSchema
+    // Example for OHLCVSchema:
+    describe("OHLCVSchema", () => {
+        test("should validate correct OHLCV data", () => {
+            const data = {
+                timestamp: 1678886400000,
+                open: 30000,
+                high: 30500,
+                low: 29800,
+                close: 30200,
+                volume: 100.5,
+            };
+            const parsed = OHLCVSchema.safeParse(data);
+            expect(parsed.success).toBe(true);
+        });
+    });
+});
+
+console.log("src/models/market.test.ts loaded");

--- a/src/models/market.ts
+++ b/src/models/market.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+
+// Based on models.MarketDetails in Python
+export const MarketDetailsSchema = z.object({
+    symbol: z.string(),
+    base_asset: z.string(),
+    quote_asset: z.string(),
+    tick_size: z.string().transform(parseFloat), // Assuming string from API, convert to number
+    min_order_size: z.string().transform(parseFloat),
+    max_order_size: z.string().transform(parseFloat),
+    lot_size: z.string().transform(parseFloat),
+    contract_type: z.string(), // e.g., "PERP", "PERP_OPTION"
+    asset_kind: z.string(), // e.g., "PERP", "PERP_OPTION" (might be same as contract_type or more specific)
+    // Add other fields from Python's MarketDetails model as needed
+    // e.g., created_at, updated_at, status, etc.
+    // For now, keeping it aligned with what's explicitly used or mentioned.
+    is_active: z.boolean().optional(), // Assuming this might exist
+    underlying_asset: z.string().optional(), // For derivatives like options/futures
+});
+export type MarketDetails = z.infer<typeof MarketDetailsSchema>;
+export const MarketDetailsArraySchema = z.array(MarketDetailsSchema);
+
+// Based on models.MarketSummary in Python
+export const MarketSummarySchema = z.object({
+    symbol: z.string(),
+    mark_price: z.string().transform(parseFloat),
+    last_price: z.string().transform(parseFloat),
+    open_interest: z.string().transform(parseFloat),
+    high_price_24h: z.string().transform(parseFloat), // Python had high_price
+    low_price_24h: z.string().transform(parseFloat),  // Python had low_price
+    volume_24h: z.string().transform(parseFloat),     // Python had volume
+    price_change_percent_24h: z.string().transform(parseFloat), // Python had price_change_percent
+    // Paradex API might return these as strings, so parsing them
+    // Ensure the field names match the JS SDK or direct API response
+    // The Python model was: symbol, mark_price, last_price, open_interest, high_price, low_price, volume, price_change_percent
+    // Adjusted here to likely 24h versions if that's standard.
+});
+export type MarketSummary = z.infer<typeof MarketSummarySchema>;
+export const MarketSummaryArraySchema = z.array(MarketSummarySchema);
+
+
+// Based on models.FundingData in Python
+export const FundingDataSchema = z.object({
+    market_id: z.string(), // Or symbol
+    funding_rate: z.string().transform(parseFloat),
+    funding_time: z.number().int(), // Assuming Unix timestamp (ms or s)
+    // Add other relevant fields if any
+});
+export type FundingData = z.infer<typeof FundingDataSchema>;
+export const FundingDataArraySchema = z.array(FundingDataSchema);
+
+// For Orderbook (based on common orderbook structures and Python's implicit use)
+export const OrderbookLevelSchema = z.tuple([z.string().transform(parseFloat), z.string().transform(parseFloat)]); // [price, quantity]
+export type OrderbookLevel = z.infer<typeof OrderbookLevelSchema>;
+
+export const OrderbookSchema = z.object({
+    market_id: z.string(), // Or symbol
+    timestamp: z.number().int(), // Unix timestamp
+    bids: z.array(OrderbookLevelSchema),
+    asks: z.array(OrderbookLevelSchema),
+    // Optional sequence number or last update ID if provided by API
+    sequence: z.number().int().optional(),
+});
+export type Orderbook = z.infer<typeof OrderbookSchema>;
+
+// Based on OHLCV model in Python (for klines)
+export const OHLCVSchema = z.object({
+    timestamp: z.number().int(), // Typically Unix timestamp (ms) for start of interval
+    open: z.number(), // In Python these were float, direct number is fine in Zod
+    high: z.number(),
+    low: z.number(),
+    close: z.number(),
+    volume: z.number(),
+});
+export type OHLCV = z.infer<typeof OHLCVSchema>;
+export const OHLCVArraySchema = z.array(OHLCVSchema);
+
+
+// Based on models.Trade in Python
+export const TradeSchema = z.object({
+    id: z.string(), // Or number, depending on API
+    market_id: z.string(), // Or symbol
+    price: z.string().transform(parseFloat),
+    quantity: z.string().transform(parseFloat),
+    side: z.enum(['BUY', 'SELL']), // Or "BID"/"ASK", "Bid"/"Ask", "b"/"s" etc. - check API
+    timestamp: z.number().int(), // Unix timestamp (ms)
+    liquidation: z.boolean().optional(), // If API provides this
+    // fee: z.string().transform(parseFloat).optional(), // If applicable and provided
+    // fee_currency: z.string().optional(),
+});
+export type Trade = z.infer<typeof TradeSchema>;
+export const TradeArraySchema = z.array(TradeSchema);
+
+// Based on models.BBO in Python
+export const BBOSchema = z.object({
+    market_id: z.string(), // Or symbol
+    best_bid_price: z.string().transform(parseFloat),
+    best_bid_quantity: z.string().transform(parseFloat),
+    best_ask_price: z.string().transform(parseFloat),
+    best_ask_quantity: z.string().transform(parseFloat),
+    timestamp: z.number().int(), // Unix timestamp (ms)
+});
+export type BBO = z.infer<typeof BBOSchema>;
+
+console.log("src/models/market.ts loaded");
+
+// Note: The actual field names and types must match the responses from the @paradex/sdk.
+// The .transform(parseFloat) assumes the API returns numbers as strings. If they are already numbers,
+// then z.number() would be used directly. This is a common pattern for financial APIs.
+// Enum values (like trade side) also need to match the API's exact string values.
+// Optional fields should be marked with .optional().
+// This initial version is a direct translation of the Python models' structure.
+// It will need verification against the actual data from the Paradex JS SDK.

--- a/src/resources/market.ts
+++ b/src/resources/market.ts
@@ -1,0 +1,134 @@
+import { McpServer, McpRequest, ResourceTemplate } from "@modelcontextprotocol/sdk/server";
+import { z } from "zod";
+import { getParadexClient } from "../utils/paradex-client";
+import { Config, config as appConfig } from "../utils/config";
+import { MarketDetailsArraySchema, MarketSummarySchema, MarketDetails } from "../models/market"; // Zod schemas
+
+export function registerMarketResources(server: McpServer, config: Config) {
+
+    server.registerResource(
+        "paradex_markets_list", // Resource name
+        "paradex://markets",    // URI template (static for list)
+        { // Metadata
+            title: "Available Markets List",
+            description: "Get a list of all available markets on Paradex.",
+            // No input schema for a static list resource
+        },
+        async (uri: URL, params: Record<string, string>, mcpRequest?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Assumed JS SDK method: client.getMarkets()
+                // Python used: client.fetch_markets()
+                const response = await client.getMarkets?.();
+
+                if (!response) {
+                    throw new Error("Failed to fetch markets list from Paradex SDK.");
+                }
+
+                // Assuming response is an array of market objects or { results: [...] }
+                let marketsData: any;
+                if (Array.isArray(response)) {
+                    marketsData = response;
+                } else if (response && Array.isArray((response as any).results)) {
+                    marketsData = (response as any).results;
+                } else {
+                    throw new Error("Unexpected response structure for markets list.");
+                }
+
+                // We can validate against MarketDetailsArraySchema if the structure matches
+                const validatedMarkets = MarketDetailsArraySchema.parse(marketsData);
+
+                // The Python version returned a custom structure with success, timestamp, env, markets, count.
+                // MCP resources should return ContentPart[]
+                return {
+                    contents: [{
+                        uri: uri.href,
+                        type: "json",
+                        json: { // Replicating Python's structure within the JSON content part
+                            success: true,
+                            timestamp: new Date().toISOString(),
+                            environment: appConfig.PARADEX_ENVIRONMENT,
+                            markets: validatedMarkets, // The array of market details
+                            count: validatedMarkets.length,
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error("Error in paradex://markets resource:", error);
+                throw error;
+            }
+        }
+    );
+
+    server.registerResource(
+        "paradex_market_summary_item", // Resource name
+        new ResourceTemplate("paradex://market/summary/{market_id}", { list: undefined }), // Dynamic URI
+        { // Metadata
+            title: "Market Summary",
+            description: "Get a summary of market information for a specific trading pair.",
+            // Path parameters are defined in ResourceTemplate, not here.
+            // If there were query params, they could be in an argsSchema.
+        },
+        async (uri: URL, params: { market_id: string }, mcpRequest?: McpRequest) => {
+            // `params` will contain resolved path parameters, e.g., { market_id: "BTC-PERP" }
+            const { market_id } = params;
+            if (!market_id) {
+                throw new Error("market_id path parameter is required.");
+            }
+
+            try {
+                const client = await getParadexClient();
+                // Python used: client.fetch_markets_summary(params={"market": market_id})
+                // Assumed JS SDK: client.getMarketSummary(market_id) or client.getTicker(market_id)
+                const summaryResponse = await client.getMarketSummary?.(market_id) ?? await client.getTicker?.(market_id);
+
+
+                if (!summaryResponse) {
+                    throw new Error(`Failed to fetch market summary for ${market_id} from Paradex SDK.`);
+                }
+
+                // The Python code returned the raw summary. We should validate it.
+                const validatedSummary = MarketSummarySchema.parse(summaryResponse);
+
+                return {
+                    contents: [{
+                        uri: uri.href,
+                        type: "json",
+                        json: validatedSummary // Python returned the direct response, assuming it's the summary object
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex://market/summary/${market_id} resource:`, error);
+                // If error is due to "not found", a specific MCP error could be raised.
+                throw error;
+            }
+        }
+    );
+
+    console.log("Market resources registered.");
+}
+
+console.log("src/resources/market.ts loaded");
+
+// Notes:
+// - `paradex://markets`: Returns a list of all markets.
+// - `paradex://market/summary/{market_id}`: Uses ResourceTemplate for dynamic segment `{market_id}`.
+//   The handler receives `params` object with `market_id` property.
+// - SDK Methods: `client.getMarkets()`, `client.getMarketSummary(market_id)` are assumed.
+// - Response Validation: Zod schemas are used to parse and validate responses from the SDK.
+// - Content Structure: The Python `get_markets` resource returned a custom dict. This is replicated inside the `json`
+//   part of the MCP content. The `get_market_summary` directly returns the summary object as JSON.
+/* Integration into src/server/server.ts:
+import { registerMarketResources } from "../resources/market";
+// ...
+export function createServer(config: Config): McpServer {
+    // ...
+    registerSystemResources(server, config);
+    registerMarketResources(server, config); // Add this
+    // ...
+    return server;
+}
+*/
+/* And the import at the top of src/server/server.ts:
+import { registerMarketResources } from "../resources/market"; // Add this
+*/

--- a/src/resources/system.test.ts
+++ b/src/resources/system.test.ts
@@ -1,0 +1,97 @@
+import { expect, test, describe, mock } from "bun:test";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server";
+import { Config, config as loadedConfig } from "../utils/config"; // Import the actual loaded config for environment
+import * as paradexClientUtils from "../utils/paradex-client";
+import { registerSystemResources } from "./system";
+import { SystemConfigResourceSchema, SystemTimeSchema, SystemStateSchema } from "./system"; // Import Zod schemas from resource file itself
+
+// Mock the paradex client utility
+mock.module("../utils/paradex-client", () => ({
+    getParadexClient: mock(async () => ({
+        getSystemConfig: mock(async () => ({ // Mock data from Paradex SDK's getSystemConfig
+            chain_id: "0x1",
+            collateral_asset: "USDC",
+            fee_account: "0xFEES",
+            // other specific fields returned by the actual SDK
+            paradex_specific_key: "paradex_value"
+        })),
+        getServerTime: mock(async () => ({ // Mock data for getServerTime
+            time: Date.now()
+        })),
+        getSystemState: mock(async () => ({ // Mock data for getSystemState
+            state: "OPERATIONAL"
+        })),
+    })),
+    // getAuthenticatedParadexClient is not typically used by system resources
+    getAuthenticatedParadexClient: mock(async () => ({})),
+}));
+
+
+describe("System Resources", () => {
+    let server: McpServer;
+    // Use the actual loaded config for PARADEX_ENVIRONMENT consistency
+    const mockConfig: Config = { ...loadedConfig };
+
+    beforeEach(() => {
+        // Create a new server for each test to isolate resource registrations
+        server = new McpServer({ name: "test-mcp-server-resources", version: "0.1.0" });
+        registerSystemResources(server, mockConfig);
+    });
+
+    describe("paradex://system/config resource", () => {
+        test("should return merged system configuration", async () => {
+            const resource = server.resources.find(r => r.name === "paradex_system_config");
+            expect(resource).toBeDefined();
+            if (!resource) throw new Error("Resource not found");
+
+            const uri = new URL("paradex://system/config");
+            const result = await resource.handler(uri, {} /* params */);
+
+            expect(result.contents[0].type).toBe("json");
+            const jsonResult = result.contents[0].json as any;
+
+            expect(jsonResult.exchange).toBe("Paradex");
+            expect(jsonResult.environment).toBe(mockConfig.PARADEX_ENVIRONMENT);
+            expect(jsonResult.status).toBe("operational"); // Default from resource logic
+            expect(jsonResult.paradex_specific_key).toBe("paradex_value"); // From mock SDK
+            expect(jsonResult.collateral_asset).toBe("USDC"); // From mock SDK
+            expect(SystemConfigResourceSchema.safeParse(jsonResult).success).toBe(true);
+        });
+    });
+
+    describe("paradex://system/time resource", () => {
+        test("should return current server time from Paradex", async () => {
+            const resource = server.resources.find(r => r.name === "paradex_system_time");
+            expect(resource).toBeDefined();
+            if (!resource) throw new Error("Resource not found");
+
+            const uri = new URL("paradex://system/time");
+            const result = await resource.handler(uri, {});
+
+            expect(result.contents[0].type).toBe("json");
+            const jsonResult = result.contents[0].json as any;
+
+            expect(jsonResult.time).toBeGreaterThan(0); // Mock returns Date.now()
+            expect(SystemTimeSchema.safeParse(jsonResult).success).toBe(true);
+        });
+    });
+
+    describe("paradex://system/state resource", () => {
+        test("should return current system state from Paradex", async () => {
+            const resource = server.resources.find(r => r.name === "paradex_system_state");
+            expect(resource).toBeDefined();
+            if (!resource) throw new Error("Resource not found");
+
+            const uri = new URL("paradex://system/state");
+            const result = await resource.handler(uri, {});
+
+            expect(result.contents[0].type).toBe("json");
+            const jsonResult = result.contents[0].json as any;
+
+            expect(jsonResult.state).toBe("OPERATIONAL"); // From mock SDK
+            expect(SystemStateSchema.safeParse(jsonResult).success).toBe(true);
+        });
+    });
+});
+
+console.log("src/resources/system.test.ts loaded");

--- a/src/resources/system.ts
+++ b/src/resources/system.ts
@@ -1,0 +1,201 @@
+import { McpServer, McpRequest } from "@modelcontextprotocol/sdk/server";
+import { z } from "zod";
+import { getParadexClient, apiCall } from "../utils/paradex-client";
+import { Config, config as appConfig } from "../utils/config"; // Import the loaded config
+
+// Zod schema for SystemConfig (based on Python's client.fetch_system_config() and extra fields)
+// This will need to be aligned with the actual response from JS SDK client.getSystemConfig()
+export const SystemConfigParadexSchema = z.object({
+    // Fields from client.fetch_system_config() in Python's Paradex client
+    // These are illustrative; actual fields from JS SDK's getSystemConfig() are needed
+    chain_id: z.string().optional(), // e.g., "0x..." or number
+    collateral_asset: z.string().optional(), // e.g., "USDC"
+    fee_account: z.string().optional(), // StarkEx fee account
+    // ... other fields from the actual Paradex API response for system config
+    // The Python code did `base.update(syscfg.model_dump())`, so we merge.
+}).passthrough(); // Allow other fields not explicitly defined
+
+export const SystemConfigResourceSchema = SystemConfigParadexSchema.extend({
+    exchange: z.string(),
+    timestamp: z.string().datetime(),
+    environment: z.string(), // e.g., testnet, mainnet
+    status: z.string(), // e.g., operational
+    features: z.array(z.string()),
+    trading_hours: z.string(),
+    website: z.string().url(),
+    documentation: z.string().url(),
+});
+export type SystemConfigResource = z.infer<typeof SystemConfigResourceSchema>;
+
+
+// Zod schema for SystemTime (illustrative, based on typical time endpoint)
+export const SystemTimeSchema = z.object({
+    server_time_ms: z.number().int(), // Milliseconds since epoch
+    // Paradex Python client's fetch_system_time() returned: {"time": 1678886400000}
+    // Adjusting to match that if JS SDK is similar
+    time: z.number().int(),
+});
+export type SystemTime = z.infer<typeof SystemTimeSchema>;
+
+// Zod schema for SystemState (illustrative)
+export const SystemStateSchema = z.object({
+    status: z.string(), // e.g., "OPERATIONAL", "MAINTENANCE"
+    // Paradex Python client's fetch_system_state() returned: {"state": "OPERATIONAL"}
+    // Adjusting to match
+    state: z.string(),
+    message: z.string().optional(), // Optional message during maintenance
+});
+export type SystemState = z.infer<typeof SystemStateSchema>;
+
+
+export function registerSystemResources(server: McpServer, config: Config) {
+
+    server.registerResource(
+        "paradex_system_config", // Resource name
+        "paradex://system/config", // URI template
+        { // Metadata
+            title: "System Configuration",
+            description: "Get general market information, status, and configuration of the Paradex exchange.",
+            // No input schema for simple GET resource
+        },
+        async (uri: URL, params: Record<string, string>, mcpRequest?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Assumed JS SDK method, e.g., client.getSystemConfig()
+                const paradexSysConfig = await client.getSystemConfig?.();
+
+                if (!paradexSysConfig) {
+                    throw new Error("Failed to fetch system config from Paradex SDK.");
+                }
+
+                const baseInfo = {
+                    exchange: "Paradex",
+                    timestamp: new Date().toISOString(),
+                    environment: appConfig.PARADEX_ENVIRONMENT,
+                    status: "operational", // This might come from paradexSysConfig.status or similar
+                    features: ["perpetual_futures", "perpetual_options", "vaults"],
+                    trading_hours: "24/7",
+                    website: "https://paradex.trade/",
+                    documentation: "https://docs.paradex.com/", // Updated URL
+                };
+
+                // Merge Paradex specific config with base info
+                // The passthrough() in Zod schema allows this merging if fields are not predefined.
+                const fullConfigData = { ...baseInfo, ...paradexSysConfig };
+                const validatedConfig = SystemConfigResourceSchema.parse(fullConfigData);
+
+                return {
+                    contents: [{
+                        uri: uri.href,
+                        // text: JSON.stringify(validatedConfig, null, 2), // For text type
+                        // mimeType: "application/json"
+                        json: validatedConfig, // For json type (preferred by MCP for structured data)
+                        type: "json",
+                    }]
+                };
+            } catch (error: any) {
+                console.error("Error in paradex://system/config resource:", error);
+                // Return an MCP error structure if possible, or let server handle
+                // This might involve creating an McpError object
+                throw error;
+            }
+        }
+    );
+
+    server.registerResource(
+        "paradex_system_time",
+        "paradex://system/time",
+        {
+            title: "System Time",
+            description: "Get the current Paradex server time.",
+        },
+        async (uri: URL, params: Record<string, string>, mcpRequest?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Assumed JS SDK method: client.getServerTime()
+                // Python used client.fetch_system_time()
+                const systemTimeResponse = await client.getServerTime?.() ?? await (client as any).getSystemTime?.();
+
+                if (!systemTimeResponse) {
+                    throw new Error("Failed to fetch system time from Paradex SDK.");
+                }
+
+                const validatedTime = SystemTimeSchema.parse(systemTimeResponse);
+
+                return {
+                    contents: [{
+                        uri: uri.href,
+                        json: validatedTime,
+                        type: "json",
+                    }]
+                };
+            } catch (error: any) {
+                console.error("Error in paradex://system/time resource:", error);
+                throw error;
+            }
+        }
+    );
+
+    server.registerResource(
+        "paradex_system_state",
+        "paradex://system/state",
+        {
+            title: "System State",
+            description: "Get the current operational state of the Paradex system.",
+        },
+        async (uri: URL, params: Record<string, string>, mcpRequest?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Assumed JS SDK method: client.getSystemState()
+                // Python used client.fetch_system_state()
+                const systemStateResponse = await client.getSystemState?.();
+
+                if (!systemStateResponse) {
+                    throw new Error("Failed to fetch system state from Paradex SDK.");
+                }
+
+                const validatedState = SystemStateSchema.parse(systemStateResponse);
+
+                return {
+                    contents: [{
+                        uri: uri.href,
+                        json: validatedState,
+                        type: "json",
+                    }]
+                };
+            } catch (error: any) {
+                console.error("Error in paradex://system/state resource:", error);
+                throw error;
+            }
+        }
+    );
+
+    console.log("System resources registered.");
+}
+
+console.log("src/resources/system.ts loaded");
+
+// Notes:
+// - SDK Method Names: `client.getSystemConfig()`, `client.getServerTime()`, `client.getSystemState()` are assumed.
+//   Actual names from `@paradex/sdk` must be used.
+// - Response Structures: Zod schemas are based on Python client's responses. These need to match actual JS SDK responses.
+// - Error Handling: Throwing errors which McpServer should catch. Specific McpError types could be used.
+// - URI parameters (`params` in handler): Not used in these system resources as URIs are static.
+// - `appConfig.PARADEX_ENVIRONMENT` is used from the global config.
+// - Content type: Using `type: "json"` for structured data, which is generally preferred by MCP clients.
+//   The `json` property of the content part should contain the JS object.
+/* Integration into src/server/server.ts:
+import { registerSystemResources } from "../resources/system";
+// ...
+export function createServer(config: Config): McpServer {
+    // ...
+    registerMarketTools(server, config);
+    registerAccountTools(server, config);
+    registerSystemResources(server, config); // Add this
+    // ...
+    return server;
+}
+*/
+/* And the import at the top of src/server/server.ts:
+import { registerSystemResources } from "../resources/system"; // Add this
+*/

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,0 +1,184 @@
+import { McpServer, StdioServerTransport, StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/index.js";
+import { randomUUID } from "node:crypto";
+import { Config, config as appConfigInstance } from "../utils/config"; // Import loaded config instance
+import { registerMarketTools } from "../tools/market";
+import { registerAccountTools } from "../tools/account";
+import { registerSystemResources } from "../resources/system";
+import { registerMarketResources } from "../resources/market";
+
+// Configure logging - Bun typically uses console.log, .error, etc.
+// For more advanced logging, a library could be added, but for now, console will be used.
+
+let appConfig: Config;
+
+export function createServer(config: Config): McpServer {
+    appConfig = config;
+    const server = new McpServer({
+        name: config.SERVER_NAME,
+        version: "0.1.0", // Version can be dynamic if needed
+        // description, vendor, etc. can be added from config if available in JS SDK
+    });
+
+    // Import and register tools, resources, and prompts
+
+    // Import and call tool registration functions
+    // Using static imports for immediate registration
+    // Note: Ensure that the tool files (e.g., market.ts) only define the registration function
+    // and don't have side effects that depend on the server instance being fully ready,
+    // or ensure server instance is passed correctly.
+
+    // market.ts should export registerMarketTools
+    registerMarketTools(server, config);
+
+    // Register account tools
+    registerAccountTools(server, config);
+
+    // Placeholder for future tool modules
+    // import { registerOrderTools } from "../tools/orders";
+    // registerOrderTools(server, config);
+
+    // import { registerSystemTools } from "../tools/system";
+    // registerSystemTools(server, config);
+
+    // import { registerVaultTools } from "../tools/vaults";
+    // registerVaultTools(server, config);
+
+
+    // Similarly for resources and prompts
+    registerMarketResources(server, config); // Register market resources
+    registerSystemResources(server, config); // Register system resources
+
+    // import { registerTraderPrompts } from "../prompts/trader_prompts";
+    // registerTraderPrompts(server, config);
+
+
+    return server;
+}
+
+export async function runServer(server: McpServer, transportChoice: string, port?: number) {
+    console.info(`Starting MCP Paradex server with ${transportChoice} transport...`);
+
+    try {
+        if (transportChoice === "stdio") {
+            const transport = new StdioServerTransport();
+            await server.connect(transport);
+            console.info("MCP Server connected via stdio.");
+        } else if (transportChoice === "sse") {
+            // This is a simplified SSE setup. For production, you'd use a proper HTTP server like Express or Bun.serve
+            // The MCP SDK's StreamableHTTPServerTransport is more robust for HTTP-based comms.
+            // For Bun, you'd typically use Bun.serve:
+            if (!port) {
+                console.error("Port is required for SSE transport.");
+                process.exit(1);
+            }
+            console.info(`Attempting to start HTTP server on port ${port} for SSE-like transport.`);
+
+            // Example using StreamableHTTPServerTransport with Bun.serve
+            // This part will be refined when we set up the main index.ts
+            // For now, this illustrates the intent.
+            const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
+
+            Bun.serve({
+                port: port,
+                async fetch(req) {
+                    const url = new URL(req.url);
+                    if (url.pathname === "/mcp") {
+                        const sessionIdHeader = req.headers.get('mcp-session-id');
+                        let transport: StreamableHTTPServerTransport;
+
+                        if (sessionIdHeader && transports[sessionIdHeader]) {
+                            transport = transports[sessionIdHeader];
+                        } else {
+                            // A real client would send an initialize request first.
+                            // This is a simplified example.
+                            transport = new StreamableHTTPServerTransport({
+                                sessionIdGenerator: () => randomUUID(),
+                                onsessioninitialized: (newSessionId) => {
+                                    transports[newSessionId] = transport;
+                                    console.log(`MCP session ${newSessionId} initialized.`);
+                                },
+                            });
+                            transport.onclose = () => {
+                                if (transport.sessionId) {
+                                    delete transports[transport.sessionId];
+                                    console.log(`MCP session ${transport.sessionId} closed.`);
+                                }
+                            };
+                            // Connect this new transport to the main MCP server instance
+                            // This is a conceptual link; actual McpServer.connect might need one transport per server
+                            // or the transport itself handles multiplexing if designed for it.
+                            // The typical pattern is one McpServer instance connects to one transport instance.
+                            // For multiple HTTP clients, each would ideally get its own McpServer pipeline.
+                            // Or, a more complex transport layer is needed.
+                            // For now, let's assume a single server instance for simplicity in this file.
+                            // This part needs careful thought based on JS SDK patterns.
+                            // await server.connect(transport); // This might be problematic if server is already connected.
+                        }
+                        // return transport.handleRequest(req); // handleRequest expects specific parameters
+                        // A more complete implementation is needed here based on how StreamableHTTPServerTransport integrates.
+                        return new Response("MCP Endpoint. Correct handling pending.", { status: 200 });
+                    }
+                    return new Response("Not Found", { status: 404 });
+                },
+                error(error) {
+                    console.error("Bun server error:", error);
+                    return new Response("Internal Server Error", { status: 500 });
+                },
+            });
+            console.info(`MCP Server potentially available via HTTP on port ${port}/mcp`);
+            // Note: McpServer.connect for SSE might need a different approach or a dedicated SSE transport if not using StreamableHTTP.
+            // The Python server's "sse" likely used a specific MCP library feature for it.
+            // The JS SDK focuses on StdioServerTransport and StreamableHTTPServerTransport.
+            // For a true SSE (not full StreamableHTTP), custom logic or a simpler transport would be needed.
+        } else {
+            console.error(`Unsupported transport: ${transportChoice}`);
+            process.exit(1);
+        }
+    } catch (error) {
+        if (error instanceof Error && error.message.includes("EADDRINUSE")) {
+            console.error(`Port ${port} is already in use.`);
+        } else if (error instanceof Error) {
+            console.error(`Error running server: ${error.message}`);
+            console.error(error.stack);
+        } else {
+            console.error(`An unknown error occurred: ${error}`);
+        }
+        process.exit(1);
+    }
+}
+
+// Placeholder for where tools, resources, prompts would be registered
+// function importAndRegisterTools(server: McpServer, config: Config) { /* ... */ }
+// function importAndRegisterResources(server: McpServer, config: Config) { /* ... */ }
+// function importAndRegisterPrompts(server: McpServer, config: Config) { /* ... */ }
+
+// This file exports createServer and runServer.
+// The main entry point (e.g., src/index.ts) will use these.
+// It doesn't run the server directly.
+// Example of how it might be used in index.ts:
+//
+// import { createServer, runServer } from './server/server';
+// import { loadConfig } from './utils/config';
+//
+// async function main() {
+//   const config = loadConfig(); // Load environment variables or other config sources
+//   const server = createServer(config);
+//
+//   const transport = process.env.MCP_TRANSPORT || "stdio";
+//   const port = process.env.MCP_PORT ? parseInt(process.env.MCP_PORT) : 8080;
+//
+//   await runServer(server, transport, port);
+// }
+//
+// main().catch(error => {
+//   console.error("Failed to start server:", error);
+//   process.exit(1);
+// });
+//
+// process.on('SIGINT', () => {
+//   console.info("Server shutting down...");
+//   // Perform any cleanup here
+//   process.exit(0);
+// });
+//
+console.log("src/server/server.ts loaded");

--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -1,0 +1,311 @@
+import { McpServer, McpRequest } from "@modelcontextprotocol/sdk/server";
+import { z } from "zod";
+import { getAuthenticatedParadexClient, apiCall } from "../utils/paradex-client";
+import { Config } from "../utils/config";
+import {
+    AccountSummarySchema, AccountSummary,
+    PositionSchema, PositionArraySchema, Position,
+    FillSchema, FillArraySchema, Fill,
+    TransactionSchema, TransactionArraySchema, Transaction
+} from "../models/account"; // Zod schemas
+
+export function registerAccountTools(server: McpServer, config: Config) {
+
+    server.registerTool(
+        "paradex_account_summary",
+        {
+            title: "Get Account Summary",
+            description: "Get a snapshot of your account's current financial status and trading capacity. Use to check balance, margin, account health, and P&L.",
+            inputSchema: {}, // No input parameters
+        },
+        async (_params: {}, mcpContext?: McpRequest) => {
+            try {
+                const client = await getAuthenticatedParadexClient();
+                // Python used: await api_call(client, "account")
+                // The JS SDK might have a dedicated method like `client.getAccountSummary()` or `client.account.getSummary()`
+                // Or it might indeed be a generic call to an "/account" endpoint.
+
+                // Assuming a dedicated method or a well-defined response from a generic GET /account
+                const response = await client.getAccount?.() ?? await (client as any).getAccountSummary?.() ?? await apiCall(client, 'GET', 'account');
+
+                if (!response) {
+                    throw new Error("Failed to fetch account summary: SDK method returned no response.");
+                }
+
+                const accountSummary = AccountSummarySchema.parse(response); // Assuming response is the summary object
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: AccountSummarySchema.description || "Account financial status and trading capacity.",
+                            fields: AccountSummarySchema.openapi("AccountSummary"),
+                            results: accountSummary,
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error("Error in paradex_account_summary tool:", error);
+                // mcpContext?.error(error.message || "Failed to get account summary"); // If MCP context supports error reporting
+                throw error; // Let McpServer handle/wrap
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_account_positions",
+        {
+            title: "Get Account Positions",
+            description: "Analyze your open positions to monitor exposure, profitability, and risk. Use to check P&L, liquidation prices, and margin requirements.",
+            inputSchema: {}, // No input parameters
+        },
+        async (_params: {}, mcpContext?: McpRequest) => {
+            try {
+                const client = await getAuthenticatedParadexClient();
+                // Python used: client.fetch_positions()
+                // JS SDK equivalent: client.getPositions() or client.account.getPositions()
+                const response = await client.getPositions?.() ?? await (client as any).account?.getPositions?.();
+
+                if (!response) {
+                    throw new Error("Failed to fetch account positions: SDK method returned no response.");
+                }
+
+                let positions: Position[];
+                if (Array.isArray(response)) {
+                    positions = PositionArraySchema.parse(response);
+                } else if (response && Array.isArray((response as any).results)) { // Common API pattern
+                    positions = PositionArraySchema.parse((response as any).results);
+                } else {
+                    console.error("Unexpected response structure from positions endpoint:", response);
+                    throw new Error("Failed to parse account positions.");
+                }
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: PositionSchema.description || "Current open positions.",
+                            fields: PositionSchema.openapi("Position"), // Schema for a single position
+                            results: positions, // Array of positions
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error("Error in paradex_account_positions tool:", error);
+                throw error;
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_account_fills",
+        {
+            title: "Get Account Fills (Trade History)",
+            description: "Analyze your executed trades (fills) to evaluate performance and execution quality. Use to review trading history, calculate average entry prices, and track P&L.",
+            inputSchema: {
+                market_id: z.string().describe("Filter by market ID (e.g., 'BTC-PERP')."),
+                start_unix_ms: z.number().int().describe("Start time in Unix milliseconds."),
+                end_unix_ms: z.number().int().describe("End time in Unix milliseconds."),
+                // Optional: Add limit, order_id, etc. if supported by API/SDK
+            }
+        },
+        async (params: { market_id: string, start_unix_ms: number, end_unix_ms: number }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getAuthenticatedParadexClient();
+                // Python used: client.fetch_fills(params)
+                // JS SDK: client.getFills({ market, startTime, endTime }) or client.account.getFills(...)
+                const apiParams = {
+                    symbol: params.market_id, // Or 'market'
+                    startTime: params.start_unix_ms,
+                    endTime: params.end_unix_ms,
+                };
+                const response = await client.getFills?.(apiParams) ?? await (client as any).account?.getFills?.(apiParams);
+
+                if (!response) {
+                    throw new Error("Failed to fetch account fills: SDK method returned no response.");
+                }
+
+                let fills: Fill[];
+                 if (Array.isArray(response)) {
+                    fills = FillArraySchema.parse(response);
+                } else if (response && Array.isArray((response as any).results)) {
+                    fills = FillArraySchema.parse((response as any).results);
+                } else {
+                    console.error("Unexpected response structure from fills endpoint:", response);
+                    throw new Error("Failed to parse account fills.");
+                }
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: FillSchema.description || "Executed trades (fills).",
+                            fields: FillSchema.openapi("Fill"),
+                            results: fills,
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex_account_fills tool for market ${params.market_id}:`, error);
+                throw error;
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_account_funding_payments",
+        {
+            title: "Get Account Funding Payments",
+            description: "Track your funding payment history to understand its impact on P&L. Funding payments can significantly impact perpetual futures trading P&L.",
+            inputSchema: {
+                market_id: z.string().optional().describe("Filter by market ID (e.g., 'BTC-PERP'). If omitted, might fetch for all markets or require one."),
+                start_unix_ms: z.number().int().describe("Start time in Unix milliseconds."),
+                end_unix_ms: z.number().int().describe("End time in Unix milliseconds."),
+            }
+        },
+        async (params: { market_id?: string, start_unix_ms: number, end_unix_ms: number }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getAuthenticatedParadexClient();
+                // Python used: client.fetch_funding_payments(params)
+                // JS SDK: client.getFundingPayments({ market, startTime, endTime })
+                const apiParams: Record<string, any> = {
+                    startTime: params.start_unix_ms,
+                    endTime: params.end_unix_ms,
+                };
+                if (params.market_id) {
+                    apiParams.symbol = params.market_id; // or 'market'
+                }
+
+                const response = await client.getFundingPayments?.(apiParams) ?? await (client as any).account?.getFundingPayments?.(apiParams);
+
+                if (!response) {
+                    throw new Error("Failed to fetch funding payments: SDK method returned no response.");
+                }
+
+                // Funding payments data structure needs to be defined, assuming it's an array of objects.
+                // Let's assume it might return a generic list of transactions or specific funding payment objects.
+                // For now, returning raw response if no specific Zod schema is defined for it yet.
+                // If TransactionSchema is applicable:
+                // const fundingPayments = TransactionArraySchema.parse(response.results || response);
+
+                // The Python response was returned directly. Let's assume the response is an array of suitable objects.
+                // If not, a specific Zod schema for FundingPayment would be needed.
+                // For now, let's assume it's parseable by a generic array schema or we return it as raw json.
+                // If `TransactionSchema` is suitable (e.g. funding payments are a type of transaction):
+                let fundingPayments;
+                if (Array.isArray(response)) {
+                    fundingPayments = z.array(z.any()).parse(response); // General array
+                } else if (response && Array.isArray((response as any).results)) {
+                    fundingPayments = z.array(z.any()).parse((response as any).results);
+                } else {
+                     throw new Error("Unexpected funding payments response structure.");
+                }
+
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: "History of funding payments.",
+                            // fields: FundingPaymentSchema.openapi("FundingPayment"), // If a specific schema exists
+                            results: fundingPayments, // This might need a specific Zod schema
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex_account_funding_payments tool:`, error);
+                throw error;
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_account_transactions",
+        {
+            title: "Get Account Transactions",
+            description: "Get account transaction history, including deposits, withdrawals, trades, funding, etc. Filter by type and time.",
+            inputSchema: {
+                transaction_type: z.string().optional().describe("Filter by transaction type (e.g., 'DEPOSIT', 'WITHDRAWAL')."),
+                start_unix_ms: z.number().int().describe("Start time in Unix milliseconds."),
+                end_unix_ms: z.number().int().describe("End time in Unix milliseconds."),
+                limit: z.number().int().positive().max(1000).default(50).describe("Maximum number of transactions to return (e.g., 50). Max 1000."), // Max based on Python, adjust if different
+            }
+        },
+        async (params: { transaction_type?: string, start_unix_ms: number, end_unix_ms: number, limit?: number }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getAuthenticatedParadexClient();
+                // Python used: client.fetch_transactions(params)
+                // JS SDK: client.getTransactions({ type, startTime, endTime, limit })
+                const apiParams: Record<string, any> = {
+                    startTime: params.start_unix_ms,
+                    endTime: params.end_unix_ms,
+                    limit: params.limit || 50,
+                };
+                if (params.transaction_type) {
+                    apiParams.type = params.transaction_type;
+                }
+
+                const response = await client.getTransactions?.(apiParams) ?? await (client as any).account?.getTransactions?.(apiParams);
+
+                if (!response) {
+                    throw new Error("Failed to fetch account transactions: SDK method returned no response.");
+                }
+
+                let transactions: Transaction[];
+                if (Array.isArray(response)) {
+                    transactions = TransactionArraySchema.parse(response);
+                } else if (response && Array.isArray((response as any).results)) {
+                    transactions = TransactionArraySchema.parse((response as any).results);
+                } else {
+                    console.error("Unexpected response structure from transactions endpoint:", response);
+                    throw new Error("Failed to parse account transactions.");
+                }
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: TransactionSchema.description || "Account transaction history.",
+                            fields: TransactionSchema.openapi("Transaction"),
+                            results: transactions,
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex_account_transactions tool:`, error);
+                throw error;
+            }
+        }
+    );
+
+    console.log("All account tools registered.");
+}
+
+console.log("src/tools/account.ts loaded");
+
+// Note:
+// - Authentication is critical here: `getAuthenticatedParadexClient()` is used.
+// - SDK method names like `client.getAccount()`, `client.getPositions()` are assumptions.
+//   These need to be verified against the actual `@paradex/sdk` documentation or typings.
+// - The structure of the response from these SDK methods is also assumed to align with Zod schemas.
+//   Adjust parsing (e.g., `response.results`) as needed.
+// - Error handling: Similar to market tools, throwing errors for McpServer to handle.
+// - Return structure for MCP: `content: [{ type: "json", json: { description, fields, results } }]`
+//   is kept consistent with the pattern established for market tools.
+// - `openapi("SchemaName")` on Zod schemas is used to provide schema metadata.
+//   The actual "SchemaName" might need to be adjusted based on how it's consumed or displayed.
+/* Example of how this might be integrated into src/server/server.ts:
+import { registerAccountTools } from "../tools/account";
+// ...
+export function createServer(config: Config): McpServer {
+    // ... server creation ...
+    registerMarketTools(server, config);
+    registerAccountTools(server, config); // Add this line
+    // ... register other tools ...
+    return server;
+}
+*/
+/* And ensure the import is at the top of src/server/server.ts:
+import { registerMarketTools } from "../tools/market";
+import { registerAccountTools } from "../tools/account"; // Add this line
+*/

--- a/src/tools/market.test.ts
+++ b/src/tools/market.test.ts
@@ -1,0 +1,187 @@
+import { expect, test, describe, mock, spyOn } from "bun:test";
+import { McpServer, McpRequest } from "@modelcontextprotocol/sdk/server";
+import { z } from "zod";
+import { Config } from "../utils/config";
+import * as paradexClientUtils from "../utils/paradex-client"; // Import all as a namespace
+import { registerMarketTools }
+    from "./market";
+import { MarketDetailsSchema, MarketSummarySchema, MarketDetailsArraySchema, MarketSummaryArraySchema, OrderbookSchema, OHLCVArraySchema, TradeArraySchema, BBOSchema } from "../models/market";
+
+// Mock the paradex client utility
+// Option 1: Mock specific functions
+mock.module("../utils/paradex-client", () => ({
+    getParadexClient: mock(async () => ({
+        // Mock the client object and its methods used by market tools
+        getMarkets: mock(async () => ([ // Mock implementation for getMarkets
+            { symbol: "BTC-PERP", base_asset: "BTC", quote_asset: "USDC", tick_size: "0.1", min_order_size: "0.001", max_order_size: "100", lot_size: "1", contract_type: "PERP", asset_kind: "PERP", is_active: true },
+            { symbol: "ETH-PERP", base_asset: "ETH", quote_asset: "USDC", tick_size: "0.01", min_order_size: "0.01", max_order_size: "1000", lot_size: "1", contract_type: "PERP", asset_kind: "PERP", is_active: true },
+        ])),
+        getMarketSummaries: mock(async () => ([
+            { symbol: "BTC-PERP", mark_price: "40000", last_price: "40001", open_interest: "100", high_price_24h: "41000", low_price_24h: "39000", volume_24h: "50000", price_change_percent_24h: "2.5" },
+        ])),
+        getOrderBook: mock(async (marketId: string, { depth }: { depth?: number }) => ({
+            market_id: marketId,
+            timestamp: Date.now(),
+            bids: [["39990", "1.0"], ["39980", "2.5"]],
+            asks: [["40010", "0.5"], ["40020", "3.0"]],
+            sequence: 12345,
+        })),
+        getKlines: mock(async (params: any) => ([ // Assuming params are { symbol, resolution, startTime, endTime }
+            { timestamp: params.startTime, open: 100, high: 105, low: 95, close: 102, volume: 1000 },
+        ])),
+        getTradesHistory: mock(async (symbol: string, params: any) => ([
+             { id: "1", market_id: symbol, price: "40000", quantity: "0.1", side: "BUY", timestamp: Date.now() - 1000 },
+        ])),
+        getBBO: mock(async (marketId: string) => ({
+            market_id: marketId, best_bid_price: "39990", best_bid_quantity: "1.0", best_ask_price: "40010", best_ask_quantity: "0.5", timestamp: Date.now()
+        })),
+        // Mock other methods like getFundingRateHistory if they exist and are used
+    })),
+    getAuthenticatedParadexClient: mock(async () => ({})), // Not used by market tools usually
+    apiCall: mock(async (client: any, method: string, path: string, params?: Record<string, any>) => {
+        // Generic fallback for apiCall if used by any market tool
+        if (path === 'markets/klines') { // Example from klines tool
+             return { results: [[params?.startTime, 100,105,95,102,1000]] };
+        }
+        return { results: [] };
+    }),
+}));
+
+
+describe("Market Tools", () => {
+    let server: McpServer;
+    const mockConfig: Config = { // Provide a minimal mock config
+        NODE_ENV: "test",
+        SERVER_NAME: "test-server",
+        SERVER_PORT: 8080,
+        PARADEX_ENVIRONMENT: "testnet",
+        LOG_LEVEL: "info",
+    };
+
+    // Spy on specific client methods if needed for finer-grained assertion
+    // let getMarketsSpy: any;
+
+    beforeEach(() => {
+        server = new McpServer({ name: "test-mcp-server", version: "0.1.0" });
+        registerMarketTools(server, mockConfig);
+
+        // If using the global module mock, spies need to be on the mocked functions.
+        // This is tricky with bun:test's current module mocking.
+        // An alternative is to pass the mocked client into registration functions,
+        // but that changes the main code structure.
+
+        // For now, we rely on the mock implementations above.
+    });
+
+    describe("paradex_markets tool", () => {
+        test("should return list of markets", async () => {
+            const tool = server.tools["paradex_markets"];
+            expect(tool).toBeDefined();
+
+            const result = await tool.handler({ limit: 1, offset: 0 });
+            expect(result.content[0].type).toBe("json");
+            const jsonResult = result.content[0].json as any;
+            expect(jsonResult.results.length).toBe(1);
+            expect(jsonResult.results[0].symbol).toBe("ETH-PERP"); // Sorted reverse alphabetically by mock
+            expect(jsonResult.total).toBe(2);
+        });
+
+        test("should filter markets by market_ids", async () => {
+            const tool = server.tools["paradex_markets"];
+            const result = await tool.handler({ market_ids: ["BTC-PERP"], limit: 10, offset: 0 });
+            const jsonResult = result.content[0].json as any;
+            expect(jsonResult.results.length).toBe(1);
+            expect(jsonResult.results[0].symbol).toBe("BTC-PERP");
+        });
+    });
+
+    describe("paradex_market_summaries tool", () => {
+        test("should return market summaries", async () => {
+            const tool = server.tools["paradex_market_summaries"];
+            expect(tool).toBeDefined();
+            const result = await tool.handler({ limit: 1 });
+            const jsonResult = result.content[0].json as any;
+            expect(jsonResult.results.length).toBe(1);
+            expect(jsonResult.results[0].symbol).toBe("BTC-PERP");
+            expect(jsonResult.results[0].mark_price).toBe(40000);
+        });
+    });
+
+    describe("paradex_orderbook tool", () => {
+        test("should return orderbook for a market", async () => {
+            const tool = server.tools["paradex_orderbook"];
+            expect(tool).toBeDefined();
+            const result = await tool.handler({ market_id: "BTC-PERP", depth: 10 });
+            const jsonResult = result.content[0].json as any; // The tool returns the orderbook object directly
+            expect(jsonResult.market_id).toBe("BTC-PERP");
+            expect(jsonResult.bids.length).toBeGreaterThan(0);
+            expect(jsonResult.asks.length).toBeGreaterThan(0);
+            expect(OrderbookSchema.safeParse(jsonResult).success).toBe(true);
+        });
+    });
+
+    describe("paradex_klines tool", () => {
+        test("should return klines for a market", async () => {
+            const tool = server.tools["paradex_klines"];
+            expect(tool).toBeDefined();
+            const params = { market_id: "BTC-PERP", resolution: "60", start_unix_ms: Date.now() - 3600000, end_unix_ms: Date.now() };
+            const result = await tool.handler(params);
+            const jsonResult = result.content[0].json as any; // Returns array of klines
+            expect(Array.isArray(jsonResult)).toBe(true);
+            expect(jsonResult.length).toBeGreaterThan(0);
+            expect(jsonResult[0].open).toBe(100); // From mock
+            expect(OHLCVArraySchema.safeParse(jsonResult).success).toBe(true);
+        });
+    });
+
+    describe("paradex_trades tool", () => {
+        test("should return trades for a market", async () => {
+            const tool = server.tools["paradex_trades"];
+            expect(tool).toBeDefined();
+            const params = { market_id: "BTC-PERP", start_unix_ms: Date.now() - 3600000, end_unix_ms: Date.now() };
+            const result = await tool.handler(params);
+            const jsonResult = result.content[0].json as any;
+            expect(jsonResult.results.length).toBeGreaterThan(0);
+            expect(jsonResult.results[0].market_id).toBe("BTC-PERP");
+            expect(TradeArraySchema.safeParse(jsonResult.results).success).toBe(true);
+        });
+    });
+
+    describe("paradex_bbo tool", () => {
+        test("should return BBO for a market", async () => {
+            const tool = server.tools["paradex_bbo"];
+            expect(tool).toBeDefined();
+            const result = await tool.handler({ market_id: "BTC-PERP" });
+            const jsonResult = result.content[0].json as any;
+            expect(jsonResult.results.market_id).toBe("BTC-PERP");
+            expect(jsonResult.results.best_bid_price).toBe(39990);
+             expect(BBOSchema.safeParse(jsonResult.results).success).toBe(true);
+        });
+    });
+
+    describe("paradex_filters_model tool", () => {
+        test("should return schema for a given tool name", async () => {
+            const tool = server.tools["paradex_filters_model"];
+            expect(tool).toBeDefined();
+            const result = await tool.handler({ tool_name: "paradex_markets" });
+            const jsonResult = result.content[0].json as any;
+            expect(jsonResult.title).toBe("MarketDetails"); // ZodSchema.openapi("MarketDetails")
+            expect(jsonResult.properties.symbol).toBeDefined();
+        });
+
+        test("should throw error for unknown tool name", async () => {
+            const tool = server.tools["paradex_filters_model"];
+            let errorThrown = false;
+            try {
+                await tool.handler({ tool_name: "unknown_tool" as any });
+            } catch (e: any) {
+                errorThrown = true;
+                expect(e.message).toContain("No schema found for tool: unknown_tool");
+            }
+            expect(errorThrown).toBe(true);
+        });
+    });
+
+});
+
+console.log("src/tools/market.test.ts loaded");

--- a/src/tools/market.ts
+++ b/src/tools/market.ts
@@ -1,0 +1,516 @@
+import { McpServer, McpRequest } from "@modelcontextprotocol/sdk/server";
+import { z } from "zod";
+import { getParadexClient, apiCall } from "../utils/paradex-client"; // Assuming this path
+import { Config } from "../utils/config"; // Assuming this path
+import {
+    MarketDetailsSchema, MarketDetailsArraySchema, MarketDetails,
+    MarketSummarySchema, MarketSummaryArraySchema, MarketSummary,
+    FundingDataSchema, FundingDataArraySchema, FundingData,
+    OrderbookSchema, Orderbook, OrderbookLevelSchema,
+    OHLCVSchema, OHLCVArraySchema, OHLCV,
+    TradeSchema, TradeArraySchema, Trade,
+    BBOSchema, BBO
+} from "../models/market"; // Assuming this path
+import { OrderStateSchema, VaultSchema, VaultSummarySchema } from "../models/account"; // For get_filters_model
+
+// Helper for JMESPath-like filtering (basic version)
+// For full JMESPath, a library like 'jmespath' would be needed.
+// This is a simplified placeholder.
+function applySimpleFilter<T>(data: T[], filterLogic: (item: T) => boolean): T[] {
+    return data.filter(filterLogic);
+}
+
+// Placeholder for a more sophisticated JMESPath utility if needed.
+// For now, we'll rely on direct array methods or simple filters.
+// The Python version used a `jmespath_utils.apply_jmespath_filter`.
+// A full JS equivalent might be complex to implement from scratch here.
+// We will simplify filtering logic for now.
+
+
+export function registerMarketTools(server: McpServer, config: Config) {
+
+    server.registerTool(
+        "paradex_filters_model",
+        {
+            title: "Get Filters Model",
+            description: "Get detailed schema information to build precise data filters for other tools.",
+            inputSchema: {
+                tool_name: z.enum([
+                    "paradex_markets",
+                    "paradex_market_summaries",
+                    "paradex_open_orders",
+                    "paradex_orders_history",
+                    "paradex_vaults",
+                    "paradex_vault_summary",
+                    // Add other tools that support filtering if any
+                ]).describe("The name of the tool to get the filters for.")
+            }
+        },
+        async ({ tool_name } : { tool_name: string }) => {
+            const toolSchemas: Record<string, any> = {
+                "paradex_markets": MarketDetailsSchema.openapi("MarketDetails"),
+                "paradex_market_summaries": MarketSummarySchema.openapi("MarketSummary"),
+                "paradex_open_orders": OrderStateSchema.openapi("OrderState"), // Assuming OrderStateSchema is defined in account models
+                "paradex_orders_history": OrderStateSchema.openapi("OrderState"),
+                "paradex_vaults": VaultSchema.openapi("Vault"), // Assuming VaultSchema is defined
+                "paradex_vault_summary": VaultSummarySchema.openapi("VaultSummary"), // Assuming VaultSummarySchema is defined
+            };
+            if (tool_name in toolSchemas) {
+                return { content: [{ type: "json", json: toolSchemas[tool_name] }] };
+            } else {
+                // MCP error handling:
+                // throw new McpError({ code: ErrorCode.InvalidParams, message: `No schema found for tool: ${tool_name}` });
+                // For now, simple throw:
+                throw new Error(`No schema found for tool: ${tool_name}`);
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_markets",
+        {
+            title: "Get Markets",
+            description: "Find markets that match your trading criteria or get detailed market specifications. Retrieves comprehensive details about specified markets. If 'ALL' is specified or no market IDs are provided, returns details for all available markets.",
+            inputSchema: {
+                market_ids: z.array(z.string()).default(["ALL"]).describe("Market symbols to get details for (e.g., ['BTC-PERP', 'ETH-PERP']). Default is ['ALL']."),
+                // JMESPath support is complex. For now, we'll simplify or omit.
+                // jmespath_filter: z.string().optional().describe("JMESPath expression to filter, sort, or limit the results."),
+                limit: z.number().int().positive().max(100).default(10).describe("Limit the number of results."),
+                offset: z.number().int().nonnegative().default(0).describe("Offset the results."),
+            }
+        },
+        async (params: { market_ids?: string[], limit?: number, offset?: number }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // In @paradex/sdk, fetching markets is likely:
+                const response = await client.getMarkets(); // This is an assumed method based on common SDK patterns
+
+                // The actual response structure from client.getMarkets() needs to be known.
+                // Assuming it returns an array of market detail objects.
+                // If it's structured like { results: [...] }, then:
+                // let details: MarketDetails[] = MarketDetailsArraySchema.parse(response.results);
+                // For now, let's assume `response` is directly the array or has a known structure
+
+                // This is a placeholder parse, actual parsing depends on SDK's response shape
+                let details: MarketDetails[];
+                if (Array.isArray(response)) {
+                    details = MarketDetailsArraySchema.parse(response);
+                } else if (response && Array.isArray((response as any).results)) { // Common API pattern
+                    details = MarketDetailsArraySchema.parse((response as any).results);
+                } else {
+                    console.error("Unexpected response structure from client.getMarkets():", response);
+                    throw new Error("Failed to parse market details from Paradex API.");
+                }
+
+                const marketIds = params.market_ids || ["ALL"];
+                if (!(marketIds.includes("ALL"))) {
+                    details = details.filter(detail => marketIds.includes(detail.symbol));
+                }
+
+                // JMESPath filtering was here. Simplified:
+                // if (params.jmespath_filter) {
+                //     mcpContext?.notify({ type: "info", message: "JMESPath filtering is not fully supported in this version. Basic filtering applied." });
+                //     // Basic filtering example (e.g., filter by base_asset if filter was "[?base_asset=='BTC']")
+                //     // This would need a proper JMESPath parser or simplified query language.
+                // }
+
+                const sortedDetails = details.sort((a, b) => b.symbol.localeCompare(a.symbol)); // reverse: True in Python
+
+                const offset = params.offset ?? 0;
+                const limit = params.limit ?? 10;
+                const paginatedDetails = sortedDetails.slice(offset, offset + limit);
+
+                return {
+                    content: [{
+                        type: "json", // Using JSON content type for structured data
+                        json: {
+                            description: MarketDetailsSchema.description || "Details for specified markets.",
+                            fields: MarketDetailsSchema.openapi("MarketDetails"), // Or a simplified schema representation
+                            results: paginatedDetails,
+                            total: sortedDetails.length,
+                            limit: limit,
+                            offset: offset,
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error("Error in paradex_markets tool:", error);
+                // Propagate error to MCP client
+                // This requires knowing how McpServer expects errors to be thrown or returned.
+                // throw new McpError({ code: ErrorCode.InternalError, message: error.message || "Failed to fetch market details" });
+                throw error; // Let McpServer handle it or wrap it
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_market_summaries",
+        {
+            title: "Get Market Summaries",
+            description: "Identify the most active or volatile markets and get current market conditions. Retrieves current market summary information. If 'ALL' is specified or no market IDs are provided, returns summaries for all available markets.",
+            inputSchema: {
+                market_ids: z.array(z.string()).default(["ALL"]).describe("Market symbols to get summaries for. Default ['ALL']."),
+                // jmespath_filter: z.string().optional().describe("JMESPath expression to filter, sort, or limit the results."),
+                limit: z.number().int().positive().max(100).default(10).describe("Limit the number of results."),
+                offset: z.number().int().nonnegative().default(0).describe("Offset the results."),
+            }
+        },
+        async (params: { market_ids?: string[], limit?: number, offset?: number }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Assumed SDK method: client.getMarketSummaries() or client.getTickers()
+                // Python used: client.fetch_markets_summary(params={"market": "ALL"})
+                // The `market: "ALL"` suggests it might fetch all and then filter, or the API supports "ALL".
+                // Let's assume the JS SDK has a method that can fetch all or specific summaries.
+                // For now, client.getMarketSummaries() is a placeholder for such a method.
+                const response = await client.getMarketSummaries ? await client.getMarketSummaries() : await client.getTickers(); // Or similar method
+
+                let summaries: MarketSummary[];
+                if (Array.isArray(response)) {
+                    summaries = MarketSummaryArraySchema.parse(response);
+                } else if (response && Array.isArray((response as any).results)) {
+                    summaries = MarketSummaryArraySchema.parse((response as any).results);
+                } else if (response && typeof response === 'object' && !Array.isArray(response)) {
+                    // If it returns an object where keys are symbols and values are summaries
+                    summaries = MarketSummaryArraySchema.parse(Object.values(response));
+                }
+                else {
+                    console.error("Unexpected response structure from client.getMarketSummaries():", response);
+                    throw new Error("Failed to parse market summaries from Paradex API.");
+                }
+
+                const marketIds = params.market_ids || ["ALL"];
+                if (!(marketIds.includes("ALL"))) {
+                    summaries = summaries.filter(summary => marketIds.includes(summary.symbol));
+                }
+
+                // JMESPath filtering simplified/omitted for now
+
+                const sortedSummaries = summaries.sort((a, b) => b.symbol.localeCompare(a.symbol)); // reverse: True
+
+                const offset = params.offset ?? 0;
+                const limit = params.limit ?? 10;
+                const paginatedSummaries = sortedSummaries.slice(offset, offset + limit);
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: MarketSummarySchema.description || "Summary information for specified markets.",
+                            fields: MarketSummarySchema.openapi("MarketSummary"),
+                            results: paginatedSummaries,
+                            total: sortedSummaries.length,
+                            limit: limit,
+                            offset: offset,
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error("Error in paradex_market_summaries tool:", error);
+                throw error;
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_funding_data",
+        {
+            title: "Get Funding Data",
+            description: "Analyze funding rates for potential funding arbitrage or to understand holding costs. This data is critical for perpetual futures traders.",
+            inputSchema: {
+                market_id: z.string().describe("Market symbol to get funding data for (e.g., 'BTC-PERP')."),
+                start_unix_ms: z.number().int().describe("Start time in Unix milliseconds."),
+                end_unix_ms: z.number().int().describe("End time in Unix milliseconds."),
+            }
+        },
+        async (params: { market_id: string, start_unix_ms: number, end_unix_ms: number }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Assumed SDK method: client.getFundingRatesHistory(marketId, { startTime, endTime }) or similar
+                // Python used: client.fetch_funding_data(params={"market": market_id, "start_at": start_unix_ms, "end_at": end_unix_ms})
+                const apiParams = {
+                    symbol: params.market_id, // SDK might use 'symbol' or 'market'
+                    startTime: params.start_unix_ms,
+                    endTime: params.end_unix_ms
+                };
+                // This is a highly assumed method name and parameter structure
+                const response = await client.getFundingRateHistory?.(params.market_id, apiParams) ?? await (client as any).getFundingData?.(apiParams);
+
+
+                let fundingDataList: FundingData[];
+                if (Array.isArray(response)) {
+                    fundingDataList = FundingDataArraySchema.parse(response);
+                } else if (response && Array.isArray((response as any).results)) {
+                    fundingDataList = FundingDataArraySchema.parse((response as any).results);
+                } else {
+                    console.error("Unexpected response structure from client.getFundingData():", response);
+                    throw new Error("Failed to parse funding data from Paradex API.");
+                }
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: FundingDataSchema.description || `Funding data for ${params.market_id}.`,
+                            fields: FundingDataSchema.openapi("FundingData"),
+                            results: fundingDataList,
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex_funding_data tool for ${params.market_id}:`, error);
+                throw error;
+            }
+        }
+    );
+
+    // Valid orderbook depth values, similar to Python's OrderbookDepth Enum
+    const OrderbookDepthEnum = z.enum(["5", "10", "20", "50", "100"]).transform(Number).pipe(z.number().int());
+    // Or more directly if the API takes numbers:
+    // const OrderbookDepthEnum = z.nativeEnum({ SHALLOW: 5, MEDIUM: 10, DEEP: 20, VERY_DEEP: 50, FULL: 100 });
+    // For now, let's use specific numbers as per Python example.
+
+    server.registerTool(
+        "paradex_orderbook",
+        {
+            title: "Get Orderbook",
+            description: "Analyze market depth and liquidity to optimize order entry and execution. Understanding the orderbook is essential for effective trade execution.",
+            inputSchema: {
+                market_id: z.string().describe("Market symbol to get orderbook for (e.g., 'BTC-PERP')."),
+                depth: z.number().int().pipe(z.enum([5, 10, 20, 50, 100])).default(10).describe("The depth of the orderbook to retrieve (e.g., 5, 10, 20, 50, 100). Default 10.")
+            }
+        },
+        async (params: { market_id: string, depth?: 5 | 10 | 20 | 50 | 100 }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Assumed SDK method: client.getOrderbook(marketId, { depth })
+                // Python used: client.fetch_orderbook(market_id, params={"depth": depth})
+                const response = await client.getOrderBook?.(params.market_id, { depth: params.depth }); // More likely: client.getOrderBook(symbol, depth)
+
+                if (!response) { // Ensure response is not undefined if SDK method is optional a la `?.`
+                     throw new Error("Failed to fetch orderbook: SDK method not found or returned undefined.");
+                }
+
+                // The response from `fetch_orderbook` in Python was returned directly.
+                // We should parse it against our OrderbookSchema for validation and typing.
+                const orderbook = OrderbookSchema.parse(response);
+
+                return {
+                    content: [{
+                        type: "json",
+                        // The Python version returned the direct response.
+                        // Here we return the parsed and validated object.
+                        // It might be useful to also include schema/description if that was the Python server's pattern.
+                        json: orderbook // Python version returned the raw response, assuming it matched the implicit structure.
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex_orderbook tool for ${params.market_id}:`, error);
+                throw error;
+            }
+        }
+    );
+
+    // KLinesResolutionEnum from Python
+    const KLinesResolutionEnum = z.enum(["1", "3", "5", "15", "30", "60"]).describe("Time resolution of klines/candlesticks.");
+    // If the API expects numbers:
+    // const KLinesResolutionNumberEnum = z.enum([1, 3, 5, 15, 30, 60]);
+
+    server.registerTool(
+        "paradex_klines",
+        {
+            title: "Get Klines (Candlestick Data)",
+            description: "Analyze historical price patterns for technical analysis and trading decisions. Candlestick data is fundamental for most technical analysis.",
+            inputSchema: {
+                market_id: z.string().describe("Market symbol to get klines for (e.g., 'BTC-PERP')."),
+                resolution: KLinesResolutionEnum.describe("The time resolution of the klines (e.g., '1', '5', '60' for 1m, 5m, 1h)."),
+                start_unix_ms: z.number().int().describe("Start time in Unix milliseconds."),
+                end_unix_ms: z.number().int().describe("End time in Unix milliseconds."),
+            }
+        },
+        async (params: { market_id: string, resolution: string, start_unix_ms: number, end_unix_ms: number }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Python used: api_call(client, "markets/klines", params={...})
+                // This suggests a direct API call rather than a dedicated SDK method in Python's case,
+                // or the SDK method was a thin wrapper.
+                // Let's assume the JS SDK might have a dedicated method:
+                const apiParams = {
+                    symbol: params.market_id,
+                    resolution: params.resolution, // JS SDK might expect number or string
+                    startTime: params.start_unix_ms, // or start_at
+                    endTime: params.end_unix_ms,   // or end_at
+                };
+
+                // Assumed SDK method: client.getKlines(apiParams) or client.getOHLCV(apiParams)
+                const response = await client.getKlines?.(apiParams) ?? await client.getOHLCV?.(apiParams)
+                                 ?? await apiCall(client, 'GET', `markets/klines`, apiParams); // Fallback to generic if specific not found
+
+                let klines: OHLCV[];
+                // Python constructed OHLCV objects from a list of lists.
+                // The JS SDK might return objects directly or a similar structure.
+                if (response && Array.isArray((response as any).results) && Array.isArray((response as any).results[0])) {
+                    // Matches Python's structure: results: [[ts, o, h, l, c, v], ...]
+                    const rawKlines = (response as any).results as number[][];
+                    klines = OHLCVArraySchema.parse(
+                        rawKlines.map(k => ({
+                            timestamp: k[0],
+                            open: k[1],
+                            high: k[2],
+                            low: k[3],
+                            close: k[4],
+                            volume: k[5],
+                        }))
+                    );
+                } else if (Array.isArray(response)) { // If SDK returns array of OHLCV objects
+                    klines = OHLCVArraySchema.parse(response);
+                } else if (response && Array.isArray((response as any).results)) { // if SDK returns { results: [OHLCVObject, ...] }
+                     klines = OHLCVArraySchema.parse((response as any).results);
+                }
+                else {
+                    console.error("Unexpected response structure from klines endpoint:", response);
+                    throw new Error("Failed to parse klines data from Paradex API.");
+                }
+
+                return {
+                    content: [{
+                        type: "json", // Python returned a list of OHLCV objects
+                        json: klines
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex_klines tool for ${params.market_id}:`, error);
+                throw error;
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_trades",
+        {
+            title: "Get Trades",
+            description: "Analyze actual market transactions to understand market sentiment and liquidity. Trade data provides insights into actual market activity.",
+            inputSchema: {
+                market_id: z.string().describe("Market symbol to get trades for (e.g., 'BTC-PERP')."),
+                start_unix_ms: z.number().int().describe("Start time in Unix milliseconds."),
+                end_unix_ms: z.number().int().describe("End time in Unix milliseconds."),
+            }
+        },
+        async (params: { market_id: string, start_unix_ms: number, end_unix_ms: number }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Python used: client.fetch_trades(params={...})
+                // Assumed JS SDK method: client.getTrades(marketId, { startTime, endTime }) or similar
+                const apiParams = {
+                    symbol: params.market_id,
+                    startTime: params.start_unix_ms,
+                    endTime: params.end_unix_ms,
+                };
+                const response = await client.getTradesHistory?.(params.market_id, apiParams) ?? await (client as any).getTrades?.(apiParams);
+
+
+                let trades: Trade[];
+                if (Array.isArray(response)) {
+                    trades = TradeArraySchema.parse(response);
+                } else if (response && Array.isArray((response as any).results)) {
+                    trades = TradeArraySchema.parse((response as any).results);
+                } else {
+                    console.error("Unexpected response structure from trades endpoint:", response);
+                    throw new Error("Failed to parse trades data from Paradex API.");
+                }
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: TradeSchema.description || `Trade history for ${params.market_id}.`,
+                            fields: TradeSchema.openapi("Trade"),
+                            results: trades,
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex_trades tool for ${params.market_id}:`, error);
+                throw error;
+            }
+        }
+    );
+
+    server.registerTool(
+        "paradex_bbo",
+        {
+            title: "Get BBO (Best Bid and Offer)",
+            description: "Get the current best available prices for immediate execution decisions. The BBO provides the most essential price information with minimal data.",
+            inputSchema: {
+                market_id: z.string().describe("Market symbol to get BBO for (e.g., 'BTC-PERP')."),
+            }
+        },
+        async (params: { market_id: string }, mcpContext?: McpRequest) => {
+            try {
+                const client = await getParadexClient();
+                // Python used: client.fetch_bbo(market_id)
+                // Assumed JS SDK method: client.getBBO(marketId) or client.getTicker(marketId) if BBO is part of ticker
+                const response = await client.getBBO?.(params.market_id) ?? await client.getBestBidOffer?.(params.market_id);
+
+                if (!response) {
+                    throw new Error("Failed to fetch BBO: SDK method not found or returned undefined.");
+                }
+
+                const bbo = BBOSchema.parse(response);
+
+                return {
+                    content: [{
+                        type: "json",
+                        json: {
+                            description: BBOSchema.description || `Best Bid and Offer for ${params.market_id}.`,
+                            fields: BBOSchema.openapi("BBO"), // Or a simplified schema
+                            results: bbo, // Python returned a dict with BBO model + description/fields
+                        }
+                    }]
+                };
+            } catch (error: any) {
+                console.error(`Error in paradex_bbo tool for ${params.market_id}:`, error);
+                throw error;
+            }
+        }
+    );
+
+    console.log("All market tools registered.");
+}
+
+console.log("src/tools/market.ts loaded");
+
+// Note:
+// - The actual method `client.getMarkets()` and its response structure are assumptions.
+//   This will need to be validated against the `@paradex/sdk`.
+// - JMESPath filtering is complex; a full JS implementation is out of scope for this direct translation.
+//   Simplified filtering or using a library would be needed. For now, it's mostly omitted.
+// - Error handling: Throwing errors directly might be okay, or MCP might have specific error types/formats.
+// - The `fields` in the response: Python used `model_json_schema()`. Zod's `.openapi()` can generate
+//   OpenAPI-compatible schemas, or a custom schema representation might be needed if MCP expects a specific format.
+// - Context (`ctx` in Python tools for `ctx.error`) is available as the second argument in MCP tool handlers.
+//   It can be used for notifications (`mcpContext?.notify(...)`) or other context-aware actions.
+// - The `apiCall` utility might be used if direct SDK methods are not available for some specific data points,
+//   but typed SDK methods are always preferred.
+// - `parseFloat` was used in Zod schemas assuming string numbers from API. If numbers, adjust schema.
+// - `content: [{ type: "json", json: ... }]` is one way to return structured data.
+//   MCP also supports `text` and other types. For complex objects, `json` is suitable.
+//   The Python server often returned a dict that was implicitly JSON-serialized.
+//   The JS SDK might expect a specific structure for tool results (e.g., direct object or `{ content: [...] }`).
+//   The example `({ content: [{ type: "text", text: String(a + b) }] })` from MCP SDK docs suggests this structure.
+//   The Python server's return dict with "description", "fields", "results" needs to be mapped to this.
+//   A common pattern for complex data is to put the whole structure inside a single `json` content part.
+/* Example of how this might be integrated into src/server/server.ts:
+import { registerMarketTools } from "../tools/market";
+
+export function createServer(config: Config): McpServer {
+    // ... server creation ...
+    registerMarketTools(server, config);
+    // ... register other tools ...
+    return server;
+}
+*/
+/* And in src/index.ts, ensure server/server.ts is imported, which in turn imports and registers tools:
+import { createServer, runServer } from './server/server'; // This should trigger registrations
+// ... rest of main function ...
+*/

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+// Define a schema for environment variables for validation and type safety
+const envSchema = z.object({
+    NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+    SERVER_NAME: z.string().default('mcp-paradex-ts'),
+    SERVER_PORT: z.preprocess(
+        (val) => (typeof val === 'string' ? parseInt(val, 10) : val),
+        z.number().int().positive().default(8080)
+    ),
+    PARADEX_ENVIRONMENT: z.enum(['testnet', 'mainnet']).default('testnet'),
+    // Optional: L1_ADDRESS and L1_PRIVATE_KEY were in Python config but might not be directly used by paradex/sdk
+    // PARADEX_L1_ADDRESS: z.string().optional(),
+    // PARADEX_L1_PRIVATE_KEY: z.string().optional(), // Be careful with exposing private keys
+    PARADEX_ACCOUNT_PRIVATE_KEY: z.string().optional(), // For authenticated endpoints
+    LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+});
+
+export type Config = z.infer<typeof envSchema>;
+
+let loadedConfig: Config;
+
+export function loadConfig(): Config {
+    if (loadedConfig) {
+        return loadedConfig;
+    }
+
+    const parsedEnv = envSchema.safeParse(process.env);
+
+    if (!parsedEnv.success) {
+        console.error('❌ Invalid environment variables:', parsedEnv.error.format());
+        // Output details for each error
+        for (const issue of parsedEnv.error.issues) {
+            console.error(`  - ${issue.path.join('.')}: ${issue.message}`);
+        }
+        throw new Error('Invalid environment variables. Check console for details.');
+    }
+
+    loadedConfig = parsedEnv.data;
+
+    // Set global log level (simple version)
+    // A more sophisticated logger would handle this better
+    // console.log(`Log level set to: ${loadedConfig.LOG_LEVEL}`); // Example
+
+    return loadedConfig;
+}
+
+// Load config on import to make it available immediately
+// This also means it will throw an error on import if config is invalid.
+try {
+    loadedConfig = loadConfig();
+    console.log("Configuration loaded successfully.");
+    // console.log("Paradex Environment:", loadedConfig.PARADEX_ENVIRONMENT);
+    // console.log("Server Port:", loadedConfig.SERVER_PORT);
+} catch (error) {
+    console.error("Failed to load configuration during module initialization:", error);
+    // Depending on the application's needs, you might want to exit here
+    // or allow the application to attempt to run with default/partial config.
+    // For a server, exiting is often safer.
+    process.exit(1);
+}
+
+export const config: Config = loadedConfig;
+
+console.log("src/utils/config.ts loaded");

--- a/src/utils/paradex-client.ts
+++ b/src/utils/paradex-client.ts
@@ -1,0 +1,175 @@
+import { ParadexApiClient, ParadexAccount, Environment } from "@paradex/sdk";
+import { config } from "./config"; // Assuming your config loader
+
+let paradexApiClient: ParadexApiClient | null = null;
+let clientLock = false; // Simple lock mechanism
+
+async function initializeClient(): Promise<ParadexApiClient> {
+    if (paradexApiClient) {
+        return paradexApiClient;
+    }
+
+    if (clientLock) {
+        // Wait for the client to be initialized by another concurrent call
+        return new Promise((resolve, reject) => {
+            const interval = setInterval(() => {
+                if (paradexApiClient) {
+                    clearInterval(interval);
+                    resolve(paradexApiClient);
+                }
+                // Optional: Add a timeout to prevent infinite waiting
+            }, 100);
+        });
+    }
+
+    clientLock = true;
+
+    try {
+        console.log(`Initializing Paradex client for environment: ${config.PARADEX_ENVIRONMENT}`);
+        const pdxEnv = config.PARADEX_ENVIRONMENT === 'mainnet' ? Environment.MAINNET : Environment.TESTNET;
+
+        const client = new ParadexApiClient(pdxEnv);
+
+        if (config.PARADEX_ACCOUNT_PRIVATE_KEY) {
+            console.log("Authenticating Paradex client...");
+            // The @paradex/sdk might handle system config fetching internally or require manual steps.
+            // The Python version fetched system_config first, then used it to initialize ParadexAccount.
+            // Let's check if ParadexAccount in JS SDK needs similar explicit config or can derive it.
+            // Based on typical JS SDK patterns, it might be simpler.
+            // If `client.account.login()` or similar exists and takes the private key, that would be it.
+            // The v0.6.0 SDK's structure for ParadexAccount isn't immediately obvious from NPM page alone.
+            // Assuming a structure like this for now, will need to verify with actual SDK usage/docs if possible.
+
+            // The Python SDK did:
+            // response = _paradex_client.fetch_system_config()
+            // acc = ParadexAccount(config=response, l1_address="0x0...", l2_private_key=config.PARADEX_ACCOUNT_PRIVATE_KEY)
+            // _paradex_client.init_account(acc)
+
+            // Attempting to replicate:
+            const systemConfig = await client.getSystemConfig(); // Assumes such a method exists and returns necessary config
+
+            if (!systemConfig) {
+                throw new Error("Failed to fetch system config for account initialization.");
+            }
+
+            // The JS SDK's ParadexAccount constructor or an init method might differ.
+            // Placeholder for L1 address, as it was hardcoded to a zero address in the Python client
+            // when only L2 private key was used. The JS SDK might not require it if L2 key is primary.
+            const l1Address = "0x0000000000000000000000000000000000000000";
+
+            // This is a guess based on the Python SDK. The actual JS SDK `ParadexAccount`
+            // might take different parameters or be initialized differently.
+            // For instance, it might take the ParadexApiClient instance and the private key.
+            const account = new ParadexAccount(
+                client, // Or systemConfig, depending on JS SDK
+                l1Address,
+                config.PARADEX_ACCOUNT_PRIVATE_KEY
+            );
+            // Then, associate this account with the client
+            client.setAccount(account); // Assuming a method like this exists
+
+            // Or, more simply, the client itself might have a login method:
+            // await client.login(config.PARADEX_ACCOUNT_PRIVATE_KEY);
+
+            console.log("Paradex client authenticated (simulated - actual method depends on SDK).");
+        } else {
+            console.log("Paradex client initialized without authentication (public endpoints only).");
+        }
+
+        paradexApiClient = client;
+        return paradexApiClient;
+    } catch (error) {
+        console.error("Error initializing Paradex client:", error);
+        throw error;
+    } finally {
+        clientLock = false;
+    }
+}
+
+export async function getParadexClient(): Promise<ParadexApiClient> {
+    if (!paradexApiClient) {
+        return initializeClient();
+    }
+    return paradexApiClient;
+}
+
+export async function getAuthenticatedParadexClient(): Promise<ParadexApiClient> {
+    const client = await getParadexClient();
+    // The check for authentication needs to align with how @paradex/sdk indicates it.
+    // This could be checking if `client.account` is set, or a specific property/method.
+    if (!client.account) { // Assuming `client.account` holds the ParadexAccount instance after auth
+        throw new Error("Paradex client is not authenticated. PARADEX_ACCOUNT_PRIVATE_KEY might be missing or invalid.");
+    }
+    return client;
+}
+
+/**
+ * Make a direct API call to Paradex.
+ * This is a generic wrapper. Specific methods on the client should be preferred.
+ * @param method HTTP method (e.g., 'GET', 'POST')
+ * @param path The API path to call (e.g., '/markets')
+ * @param params Optional parameters for the API call. For GET, these are query params. For POST, this is the body.
+ * @returns The response from the API call.
+ */
+export async function apiCall<T = any>(
+    client: ParadexApiClient,
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE', // Extend as needed
+    path: string,
+    params?: Record<string, any>
+): Promise<T> {
+    try {
+        console.info(`Calling Paradex API: ${method} ${path} with params:`, params || {});
+        // The @paradex/sdk likely has methods like client.get(path, params), client.post(path, body), etc.
+        // This generic apiCall is less type-safe than using direct SDK methods if available.
+        // Example:
+        if (method === 'GET') {
+            // Assuming a generic `request` method or specific ones like `get`, `post`.
+            // The `client.get(path, params)` was from Python SDK. JS SDK might differ.
+            // Let's assume a generic `client.request(method, path, params)` for now if specific ones aren't known.
+            // Or, more likely, client.get(path, { params: queryParams })
+            // For now, this is a placeholder for how the Python client's generic GET was used.
+            // Direct SDK methods like `client.getMarkets()` should be used instead of this generic call if they exist.
+
+            // This is a conceptual placeholder. Actual SDK usage is key.
+            // For example, if client has `getPublic`, `getPrivate` methods:
+            // return client.getPublic(path, params);
+
+            // If the JS client has a generic `axios-like` interface:
+            // return client.request({ method, url: path, params: (method === 'GET' ? params : undefined), data: (method !== 'GET' ? params : undefined) });
+
+            // Given the Python client's `client.get(client.api_url, path, params)`,
+            // the JS equivalent might be simpler if paths are relative to a base URL configured in the client.
+            // For example: (This is a common pattern, but SDK specific)
+            // const response = await (client as any)[method.toLowerCase()](path, params);
+            // return response;
+            throw new Error(`Generic apiCall for ${method} not fully implemented; use specific client methods or detail SDK's generic request signature.`);
+
+        } else if (method === 'POST') {
+            // const response = await client.post(path, params); // Example
+            // return response;
+            throw new Error(`Generic apiCall for ${method} not fully implemented.`);
+        }
+        // ... other methods
+
+        // Fallback for unknown or if direct methods are preferred:
+        console.warn(`apiCall: Consider using a specific client method for ${method} ${path} if available.`);
+        throw new Error(`apiCall for ${method} to ${path} needs specific implementation based on @paradex/sdk capabilities.`);
+
+    } catch (error) {
+        console.error(`Error calling Paradex API ${method} ${path}:`, error);
+        // Enhance error handling, e.g., parsing Paradex specific error responses
+        throw error;
+    }
+}
+
+console.log("src/utils/paradex-client.ts loaded");
+
+// Note: The authentication and generic `apiCall` parts are highly dependent on the
+// actual structure and methods provided by `@paradex/sdk`. The above is an
+// adaptation of the Python client's logic and common JS SDK patterns.
+// It will likely need adjustments once the precise SDK API is integrated.
+// For instance, `ParadexAccount` instantiation and `client.setAccount()` are assumptions.
+// The SDK might have `client.loginWithPrivateKey(key)` or similar.
+// The generic `apiCall` is also an assumption; the SDK should provide typed methods for specific endpoints.
+// For example, instead of `apiCall(client, 'GET', '/markets')`, one would ideally use `client.getMarkets()`.
+// This file serves as a starting point for that encapsulation.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This commit includes the initial translation of the MCP Paradex server from Python to TypeScript using Bun, @modelcontextprotocol/sdk, and @paradex/sdk.

Key changes:
- Project setup with package.json and tsconfig.json for Bun.
- Core server logic in src/server/server.ts using McpServer.
- Configuration management in src/utils/config.ts.
- Paradex client utility in src/utils/paradex-client.ts (with assumptions about @paradex/sdk API).
- Zod models for market and account data in src/models/.
- Translation of market tools (src/tools/market.ts).
- Translation of account tools (src/tools/account.ts).
- Translation of system resources (src/resources/system.ts).
- Translation of market resources (src/resources/market.ts).
- Basic entry point in src/index.ts.
- Outline of testing strategy and example test files for models, market tools, and system resources.

Further work needed:
- Verification and adjustment of @paradex/sdk integration based on its actual API.
- Implementation of remaining tools (orders, vaults, system) and resources (vaults).
- Translation of MCP prompts.
- Robust implementation of HTTP/SSE transport if needed.
- Comprehensive testing and bug fixing.